### PR TITLE
add-user-validates

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,16 @@
 class User < ApplicationRecord
-  validates :name, presence: true
-  validates :email, presence: true
+  validates :name, 
+    presence: true,
+    length: { in: 1..15 }
+    
+  validates :email, 
+    presence: true,
+    format: { with: /\A[a-zA-z0-9.!#$\%\&\'\*\+\/\=\?\^\_\`\{\|\}\~\-']+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+\z/ }
+  
+  validates :password, 
+    presence: true,
+    length: { in: 8..32 },
+    format: { with: /\A(?=.*?[a-zA-Z])(?=.*?\d)\w+\z/ }
   
   has_secure_password
 end


### PR DESCRIPTION
Rails 04 User新規登録に潜む問題を解決していく
  課題をやりました。
  ユーザー登録のバリデーション設定。
  
    パスワードの文字数制限を追加する
    ・パスワードの文字数を8~32文字のみ可能にしてください
    
    パスワードをアルファベット、数字の混合のみ可能にしてください
    ・アルファベットだけ、数字だけのパスワードは不可とします
    ・少なくともアルファベットと数字はそれぞれ1文字以上含まないといけないようにします
    
    メールアドレスの正規表現を追加してください
    ・いろいろな正規表現がありますが最低限「~ @ ~ . ~」の形を許可するようにしてください。
    ※ 今の段階だとメールアドレスは@マークがなくても保存できてしまいます。
　     メールアドレスは本人確認で使うことも多いので、厳密にValidationを設定します。
    
    名前の長さに制限を追加する
    ・15文字まで許可するようにValidationを設定してください。
    ※ 現状、nameカラムには空白以外制限がかかっていません。
　     string型の場合、データは255文字まで保存が可能ですが、255文字の名前を持っている人はいないでしょう。